### PR TITLE
diamondz config add

### DIFF
--- a/150179125/rollup.json
+++ b/150179125/rollup.json
@@ -1,0 +1,84 @@
+{
+  "chain": {
+    "info-json": "[{\"chain-id\":150179125,\"parent-chain-id\":421614,\"parent-chain-is-arbitrum\":true,\"chain-name\":\"diamondz-zslab\",\"chain-config\":{\"homesteadBlock\":0,\"daoForkBlock\":null,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"berlinBlock\":0,\"londonBlock\":0,\"clique\":{\"period\":0,\"epoch\":0},\"arbitrum\":{\"EnableArbOS\":true,\"AllowDebugPrecompiles\":false,\"DataAvailabilityCommittee\":true,\"InitialArbOSVersion\":32,\"GenesisBlockNum\":0,\"InitialChainOwner\":\"0x24aD9Da8Ab98Ca02690f6541a9e88903434672F2\"},\"chainId\":150179125},\"rollup\":{\"bridge\":\"0xc70786c710372e09c3871A0a49d4f9c1E74C2F9E\",\"inbox\":\"0xae8D50bD992C9AdAb585fCa17529c6cCbbA9807B\",\"sequencer-inbox\":\"0x20d8803E1746a4e9A1166e0B9F59D722F7685F5e\",\"rollup\":\"0xB4826aaB3125D8A91D8EA61a67766D9fe4Af0FaA\",\"validator-wallet-creator\":\"0x2c37dCBCE3fbe32c9Ba62892F1E41DbB023BB62b\",\"stake-token\":\"0x980B62Da83eFf3D4576C647993b0c1D7faf17c73\",\"deployed-at\":181555142}}]",
+    "name": "diamondz-zslab"
+  },
+  "parent-chain": {
+    "connection": {
+      "url": "https://sepolia-rollup.arbitrum.io/rpc"
+    }
+  },
+  "http": {
+    "addr": "0.0.0.0",
+    "port": 8449,
+    "vhosts": [
+      "*"
+    ],
+    "corsdomain": [
+      "*"
+    ],
+    "api": [
+      "eth",
+      "net",
+      "web3",
+      "arb",
+      "debug"
+    ]
+  },
+  "node": {
+    "sequencer": true,
+    "delayed-sequencer": {
+      "enable": true,
+      "use-merge-finality": false,
+      "finalize-distance": 1
+    },
+    "batch-poster": {
+      "max-size": 90000,
+      "enable": true,
+      "parent-chain-wallet": {
+        "private-key": ""
+      }
+    },
+    "staker": {
+      "enable": true,
+      "strategy": "MakeNodes",
+      "parent-chain-wallet": {
+        "private-key": ""
+      }
+    },
+    "dangerous": {
+      "no-sequencer-coordinator": true,
+      "disable-blob-reader": false
+    },
+    "bold": {
+      "strategy": "MakeNodes"
+    },
+    "data-availability": {
+      "enable": true,
+      "sequencer-inbox-address": "0x20d8803E1746a4e9A1166e0B9F59D722F7685F5e",
+      "parent-chain-node-url": "https://sepolia-rollup.arbitrum.io/rpc",
+      "rest-aggregator": {
+        "enable": true,
+        "urls": [
+          "http://localhost:9877"
+        ]
+      },
+      "rpc-aggregator": {
+        "enable": true,
+        "assumed-honest": 1,
+        "backends": "[{\"url\":\"http://localhost:9876\",\"pubkey\":\"YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\",\"signermask\":1}]"
+      }
+    }
+  },
+  "execution": {
+    "forwarding-target": "",
+    "sequencer": {
+      "enable": true,
+      "max-tx-data-size": 85000,
+      "max-block-speed": "250ms"
+    },
+    "caching": {
+      "archive": true
+    }
+  }
+}

--- a/7791/rollup.json
+++ b/7791/rollup.json
@@ -1,0 +1,84 @@
+{
+    "chain": {
+      "info-json": "[{\"chain-id\":7791,\"parent-chain-id\":42161,\"parent-chain-is-arbitrum\":true,\"chain-name\":\"diamondz-zshadow\",\"chain-config\":{\"homesteadBlock\":0,\"daoForkBlock\":null,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"berlinBlock\":0,\"londonBlock\":0,\"clique\":{\"period\":0,\"epoch\":0},\"arbitrum\":{\"EnableArbOS\":true,\"AllowDebugPrecompiles\":false,\"DataAvailabilityCommittee\":true,\"InitialArbOSVersion\":32,\"GenesisBlockNum\":0,\"MaxCodeSize\":24576,\"MaxInitCodeSize\":49152,\"InitialChainOwner\":\"0x611C342C4F9Fcc482017A1e9dde2E2692AAc27F4\"},\"chainId\":7791},\"rollup\":{\"bridge\":\"0x8B0A713F8F739473bdbb77fdcb41a63C56e58fB9\",\"inbox\":\"0x85b0A408B56c7733956802D6fDdc5412C718a270\",\"sequencer-inbox\":\"0x1184479D75cEf13B81a4cbE13fA627736E4B8Efa\",\"rollup\":\"0xB7cB2e7425A9804b8b7fa11ED6C12824E8e3cFB0\",\"validator-wallet-creator\":\"0x69A6dE0B9BeC9edb33805167327a6ABEf0C69Fd2\",\"stake-token\":\"0x82aF49447D8a07e3bd95BD0d56f35241523fBab1\",\"deployed-at\":435877045}}]",
+      "name": "diamondz-zshadow"
+    },
+    "parent-chain": {
+      "connection": {
+        "url": "https://arb1.arbitrum.io/rpc"
+      }
+    },
+    "http": {
+      "addr": "0.0.0.0",
+      "port": 8449,
+      "vhosts": [
+        "*"
+      ],
+      "corsdomain": [
+        "*"
+      ],
+      "api": [
+        "eth",
+        "net",
+        "web3",
+        "arb",
+        "debug"
+      ]
+    },
+    "node": {
+      "sequencer": true,
+      "delayed-sequencer": {
+        "enable": true,
+        "use-merge-finality": false,
+        "finalize-distance": 1
+      },
+      "batch-poster": {
+        "max-size": 90000,
+        "enable": true,
+        "parent-chain-wallet": {
+          "private-key": ""
+        }
+      },
+      "staker": {
+        "enable": true,
+        "strategy": "MakeNodes",
+        "parent-chain-wallet": {
+          "private-key": ""
+        }
+      },
+      "dangerous": {
+        "no-sequencer-coordinator": true,
+        "disable-blob-reader": false
+      },
+      "bold": {
+        "strategy": "MakeNodes"
+      },
+      "data-availability": {
+        "enable": true,
+        "sequencer-inbox-address": "0x1184479D75cEf13B81a4cbE13fA627736E4B8Efa",
+        "parent-chain-node-url": "https://arb1.arbitrum.io/rpc",
+        "rest-aggregator": {
+          "enable": true,
+          "urls": [
+            "http://localhost:9877"
+          ]
+        },
+        "rpc-aggregator": {
+          "enable": true,
+          "assumed-honest": 1,
+          "backends": "[{\"url\":\"http://localhost:9876\",\"pubkey\":\"YAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\",\"signermask\":1}]"
+        }
+      }
+    },
+    "execution": {
+      "forwarding-target": "",
+      "sequencer": {
+        "enable": true,
+        "max-tx-data-size": 85000,
+        "max-block-speed": "250ms"
+      },
+      "caching": {
+        "archive": true
+      }
+    }
+  }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new rollup/node configuration files that control chain IDs, deployment addresses, RPC endpoints, and enabled node roles; incorrect values could lead to misconfigured or insecure deployments (e.g., exposed RPC/CORS settings).
> 
> **Overview**
> Adds two new rollup node configuration files, `150179125/rollup.json` (`diamondz-zslab`, Sepolia parent) and `7791/rollup.json` (`diamondz-zshadow`, Arbitrum One parent).
> 
> Each config defines chain/rollup deployment addresses and enables sequencer + delayed sequencer, batch posting, staking, and data availability (including local aggregator backends), along with the HTTP RPC exposure settings (port `8449`, wildcard `vhosts`/CORS).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7209c3b69a4bd02e7fed3379c63188bc7d94d421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->